### PR TITLE
Use a singleton ModelAdmin to prevent delete/add actions.

### DIFF
--- a/singleton_app/admin.py
+++ b/singleton_app/admin.py
@@ -5,4 +5,20 @@ from django.contrib import admin
 
 from .models import SiteSettings
 
-admin.site.register(SiteSettings)
+
+class SingletonModelAdmin(admin.ModelAdmin):
+    """
+    Prevents Django admin users deleting the singleton or adding extra rows.
+    """
+    actions = None  # Removes the default delete action.
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def has_add_permission(self, request):
+        return False
+
+
+@admin.register(SiteSettings)
+class SiteSettingsAdmin(SingletonModelAdmin):
+    pass


### PR DESCRIPTION
Django admin still displays buttons and actions to add and delete rows; this `SingletonModelAdmin` class banishes them.